### PR TITLE
Add `safe.directory` for git

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,6 +42,7 @@ fi
 
 echo -e "\nSetting GitHub credentials..."
 git remote set-url origin "https://${GITHUB_ACTOR}:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}"
+git config --global --add safe.directory /github/workspace
 git config --global user.name "${GITHUB_ACTOR}"
 git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
 # Needed for hub binary


### PR DESCRIPTION
Should fix Docker permission errors with new git binary.

## :memo:  Brief description

<!-- Write you description here -->

<!-- Diff summary - START -->
<!-- Diff summary - END -->


## :computer:  Commits
<!-- Diff commits - START -->
<!-- Diff commits - END -->


## :file_folder:  Modified files
<!-- Diff files - START -->
<!-- Diff files - END -->


## :warning: Additional information
* [ ] Pushed to a branch with a proper name and provided proper commit message.
* [ ] Provided a clear and concise description of what the issue is.


*Check [CONTRIBUTING.md][contributing] and [CODE_OF_CONDUCT.md][code] for more information*

[contributing]: https://github.com/devops-infra/.github/blob/master/CONTRIBUTING.md
[code]: https://github.com/devops-infra/.github/blob/master/CODE_OF_CONDUCT.md
