### PR TITLE
feat: Allow check of diff between branch files to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Features:
         new_string: "** Automatic pull request**"
         get_diff: true
         ignore_users: "dependabot"
+        check_diff: true
 ```
 
 
@@ -62,6 +63,7 @@ Features:
 | github_token   | Yes      | `""`                          | GitHub token `${{ secrets.GITHUB_TOKEN }}`                                                                               |
 | assignee       | No       | `""`                          | Assignee's usernames.                                                                                                    |
 | body           | No       | *list of commits*             | Pull request body.                                                                                                       |
+| check_diff     | No       | `true`                        | Whether to check if files differ before creating a PR.                                                                   |
 | draft          | No       | `false`                       | Whether to mark it as a draft.                                                                                           |
 | get_diff       | No       | `false`                       | Whether to replace predefined comments with differences between branches - see details below.                            |
 | ignore_users   | No       | `"dependabot"`                | List of users to ignore, coma separated.                                                                                 |

--- a/action.yml
+++ b/action.yml
@@ -60,6 +60,10 @@ inputs:
     description: List of users to ignore, coma separated
     required: false
     default: "dependabot"
+  check_diff:
+    description: Whether to check if files differ before creating a PR
+    required: false
+    default: "true"
 outputs:
   url:
     description: Pull request URL.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,6 +20,7 @@ echo "  get_diff: ${INPUT_GET_DIFF}"
 echo "  old_string: ${INPUT_OLD_STRING}"
 echo "  new_string: ${INPUT_NEW_STRING}"
 echo "  ignore_users: ${INPUT_IGNORE_USERS}"
+echo "  check_diff: ${INPUT_CHECK_DIFF}"
 
 # Skip whole script to not cause errors
 IFS=',' read -r -a IGNORE_USERS <<< "${INPUT_IGNORE_USERS}"
@@ -65,10 +66,12 @@ if [[ $(git rev-parse --revs-only "${SOURCE_BRANCH}") == $(git rev-parse --revs-
   exit 0
 fi
 
-echo -e "\nComparing branches by diff..."
-if [[ -z $(git diff "remotes/origin/${TARGET_BRANCH}...remotes/origin/${SOURCE_BRANCH}") ]]; then
-  echo -e "\n[INFO] Both branches are the same. No action needed."
-  exit 0
+if [[ "${INPUT_CHECK_DIFF}" == "true" ]]; then
+  echo -e "\nComparing branches by diff..."
+  if [[ -z $(git diff "remotes/origin/${TARGET_BRANCH}...remotes/origin/${SOURCE_BRANCH}") ]]; then
+    echo -e "\n[INFO] Both branches are the same. No action needed."
+    exit 0
+  fi
 fi
 
 # sed has problems with putting multi-line strings in the next steps, and later we use # for sed


### PR DESCRIPTION
## :memo:  Brief description

In some cases, it would be nice to be able to auto-open PRs if there is just a merge commit (i.e. no change in file contents). Making this a configurable option.

<!-- Diff summary - START -->
<!-- Diff summary - END -->


## :computer:  Commits
<!-- Diff commits - START -->
<!-- Diff commits - END -->


## :file_folder:  Modified files
<!-- Diff files - START -->
<!-- Diff files - END -->


## :warning: Additional information
* [ ] Pushed to a branch with a proper name and provided proper commit message.
* [ ] Provided a clear and concise description of what the issue is.
