### PR TITLE
Set PR_NUMBER when PR is created

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -169,6 +169,7 @@ if [[ -z "${PR_NUMBER}" ]]; then
   COMMAND="hub pull-request -b ${TARGET_BRANCH} -h ${SOURCE_BRANCH} --no-edit ${ARG_LIST[@]}"
   echo -e "\nRunning: ${COMMAND}"
   URL=$(sh -c "${COMMAND}")
+  PR_NUMBER=$(gh pr view --json number -q .number ${URL})
   # shellcheck disable=SC2181
   if [[ "$?" != "0" ]]; then RET_CODE=1; fi
 else


### PR DESCRIPTION
Fixes https://github.com/devops-infra/action-pull-request/issues/104#issuecomment-1348167143

pr_number output is unset if this job creates the PR, add a gh command to retrieve the number based on the url returned by creation command.

<!-- Diff summary - START -->
<!-- Diff summary - END -->


## :computer:  Commits
<!-- Diff commits - START -->
<!-- Diff commits - END -->


## :file_folder:  Modified files
<!-- Diff files - START -->
<!-- Diff files - END -->


## :warning: Additional information
* [ ] Pushed to a branch with a proper name and provided proper commit message.
* [ x ] Provided a clear and concise description of what the issue is.


*Check [CONTRIBUTING.md][contributing] and [CODE_OF_CONDUCT.md][code] for more information*

[contributing]: https://github.com/devops-infra/.github/blob/master/CONTRIBUTING.md
[code]: https://github.com/devops-infra/.github/blob/master/CODE_OF_CONDUCT.md
